### PR TITLE
[IMP-5] Fix testnet examples

### DIFF
--- a/examples/aptos/call-contract/index.js
+++ b/examples/aptos/call-contract/index.js
@@ -30,7 +30,6 @@ async function deploy(chain, wallet) {
 
 async function execute(chains, wallet, options) {
     const args = options.args || [];
-    const calculateBridgeFee = options.calculateBridgeFee;
     const client = new AptosNetwork(process.env.APTOS_URL);
 
     for (const chain of chains) {
@@ -39,7 +38,7 @@ async function execute(chains, wallet, options) {
         chain.contract = new Contract(chain.helloWorld, HelloWorld.abi, chain.wallet);
     }
 
-    const evm = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
+    const evm = options.source
     const messageEvmToAptos = args[1] || `Hello aptos from ${evm.name}, it is ${new Date().toLocaleTimeString()}.`;
     const messageAptosToEvm = args[2] || `Hello ${evm.name} from aptos, it is ${new Date().toLocaleTimeString()}.`;
 

--- a/examples/aptos/call-contract/index.js
+++ b/examples/aptos/call-contract/index.js
@@ -30,7 +30,7 @@ async function deploy(chain, wallet) {
 
 async function execute(chains, wallet, options) {
     const args = options.args || [];
-    const getGasPrice = options.getGasPrice;
+    const calculateBridgeFee = options.calculateBridgeFee;
     const client = new AptosNetwork(process.env.APTOS_URL);
 
     for (const chain of chains) {
@@ -56,7 +56,7 @@ async function execute(chains, wallet, options) {
 
     // Set the gasLimit to 3e5 (a safe overestimate) and get the gas price.
     const gasLimit = 3e5;
-    const gasPrice = await getGasPrice(evm, 'aptos', AddressZero);
+    const gasPrice = 1;
 
     const tx = await evm.contract.setRemoteValue('aptos', `${client.owner.address()}::hello_world`, messageEvmToAptos, {
         value: BigInt(Math.floor(gasLimit * gasPrice)),

--- a/examples/aptos/token-linker/index.js
+++ b/examples/aptos/token-linker/index.js
@@ -44,7 +44,7 @@ async function deploy(chain, wallet) {
 
 async function execute(chains, wallet, options) {
     const args = options.args || [];
-    const getGasPrice = options.getGasPrice;
+    const calculateBridgeFee = options.calculateBridgeFee;
     const client = new AptosNetwork(process.env.APTOS_URL);
     const coins = new CoinClient(client);
 
@@ -85,7 +85,7 @@ async function execute(chains, wallet, options) {
 
     // Set the gasLimit to 3e5 (a safe overestimate) and get the gas price.
     const gasLimit = 3e5;
-    const gasPrice = await getGasPrice(evm, 'aptos', AddressZero);
+    const gasPrice = 1
 
     console.log(`Minting and Approving ${Number(amount1) / 1e18} ALT`);
 

--- a/examples/aptos/token-linker/index.js
+++ b/examples/aptos/token-linker/index.js
@@ -44,7 +44,6 @@ async function deploy(chain, wallet) {
 
 async function execute(chains, wallet, options) {
     const args = options.args || [];
-    const calculateBridgeFee = options.calculateBridgeFee;
     const client = new AptosNetwork(process.env.APTOS_URL);
     const coins = new CoinClient(client);
 
@@ -55,7 +54,7 @@ async function execute(chains, wallet, options) {
         chain.contract = new Contract(chain.aptosTokenLinker, TokenLinker.abi, chain.wallet);
     }
 
-    const evm = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
+    const evm = options.getSourceChain(chains);
     const amount1 = args[1] || BigInt(1e18);
     const amount2 = args[2] || BigInt(Math.floor(5e17 / 256 ** ignoreDigits));
 

--- a/examples/evm/call-contract-with-token/README.md
+++ b/examples/evm/call-contract-with-token/README.md
@@ -30,7 +30,7 @@ npm run execute evm/call-contract-with-token [local|testnet] ${srcChain} ${destC
 
 ```bash
 npm run deploy evm/call-contract-with-token local
-npm run execute evm/call-contract-with-token local "Moonbeam" "Ethereum" 100 0xBa86A5719722B02a5D5e388999C25f3333c7A9fb
+npm run execute evm/call-contract-with-token local "Avalanche" "Fantom" 100 0xBa86A5719722B02a5D5e388999C25f3333c7A9fb
 ```
 
 ### Output:

--- a/examples/evm/call-contract-with-token/index.js
+++ b/examples/evm/call-contract-with-token/index.js
@@ -26,9 +26,7 @@ async function deploy(chain, wallet) {
 
 async function execute(chains, wallet, options) {
     const args = options.args || [];
-    const calculateBridgeFee = options.calculateBridgeFee;
-    const source = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
-    const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
+    const { source, destination, calculateBridgeFee } = options;
     const amount = Math.floor(parseFloat(args[2])) * 1e6 || 10e6;
     const accounts = args.slice(3);
 

--- a/examples/evm/call-contract-with-token/index.js
+++ b/examples/evm/call-contract-with-token/index.js
@@ -30,7 +30,7 @@ async function deploy(chain, wallet) {
 
 async function execute(chains, wallet, options) {
     const args = options.args || [];
-    const getGasPrice = options.getGasPrice;
+    const calculateBridgeFee = options.calculateBridgeFee;
     const source = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
     const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
     const amount = Math.floor(parseFloat(args[2])) * 1e6 || 10e6;
@@ -49,8 +49,7 @@ async function execute(chains, wallet, options) {
     console.log('--- Initially ---');
     await logAccountBalances();
 
-    const gasLimit = 3e6;
-    const gasPrice = await getGasPrice(source, destination, AddressZero);
+    const fee = await calculateBridgeFee(source, destination);
 
     const balance = await destination.usdc.balanceOf(accounts[0]);
 
@@ -58,7 +57,7 @@ async function execute(chains, wallet, options) {
     await approveTx.wait();
 
     const sendTx = await source.contract.sendToMany(destination.name, destination.contract.address, accounts, 'aUSDC', amount, {
-        value: BigInt(Math.floor(gasLimit * gasPrice)),
+        value: fee,
     });
     await sendTx.wait();
 

--- a/examples/evm/call-contract-with-token/index.js
+++ b/examples/evm/call-contract-with-token/index.js
@@ -57,8 +57,11 @@ async function execute(chains, wallet, options) {
 
     while (true) {
         const updatedBalance = await destination.usdc.balanceOf(accounts[0]);
-        console.log(updatedBalance.toString(), balance.toString());
-        if (updatedBalance.gt(balance)) break;
+
+        if (updatedBalance.gt(balance)) {
+            break;
+        }
+
         await sleep(1000);
     }
 

--- a/examples/evm/call-contract-with-token/index.js
+++ b/examples/evm/call-contract-with-token/index.js
@@ -1,10 +1,6 @@
 'use strict';
 
-const {
-    getDefaultProvider,
-    Contract,
-    constants: { AddressZero },
-} = require('ethers');
+const { getDefaultProvider, Contract } = require('ethers');
 const {
     utils: { deployContract },
 } = require('@axelar-network/axelar-local-dev');

--- a/examples/evm/call-contract/README.md
+++ b/examples/evm/call-contract/README.md
@@ -30,7 +30,7 @@ This example deploys the contract on a local network and relays a message "Hello
 
 ```bash
 npm run deploy evm/call-contract local
-npm run execute evm/call-contract local "Moonbeam" "Avalanche" "Hello World"
+npm run execute evm/call-contract local "Fantom" "Avalanche" "Hello World"
 ```
 
 The output will be:

--- a/examples/evm/call-contract/index.js
+++ b/examples/evm/call-contract/index.js
@@ -19,7 +19,7 @@ async function deploy(chain, wallet) {
 
 async function execute(chains, wallet, options) {
     const args = options.args || [];
-    const getGasPrice = options.getGasPrice;
+    const calculateBridgeFee = options.calculateBridgeFee;
 
     const source = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
     const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
@@ -32,12 +32,10 @@ async function execute(chains, wallet, options) {
     console.log('--- Initially ---');
     await logValue();
 
-    // Set the gasLimit to 3e5 (a safe overestimate) and get the gas price.
-    const gasLimit = 3e5;
-    const gasPrice = await getGasPrice(source, destination, AddressZero);
+    const fee = await calculateBridgeFee(source, destination);
 
     const tx = await source.contract.setRemoteValue(destination.name, destination.contract.address, message, {
-        value: BigInt(Math.floor(gasLimit * gasPrice)),
+        value: fee,
     });
     await tx.wait();
 

--- a/examples/evm/call-contract/index.js
+++ b/examples/evm/call-contract/index.js
@@ -12,9 +12,8 @@ const ExecutableSample = rootRequire('./artifacts/examples/evm/call-contract/Exe
 
 async function deploy(chain, wallet) {
     console.log(`Deploying ExecutableSample for ${chain.name}.`);
-    const provider = getDefaultProvider(chain.rpc);
-    chain.wallet = wallet.connect(provider);
     chain.contract = await deployContract(wallet, ExecutableSample, [chain.gateway, chain.gasService]);
+    chain.wallet = wallet;
     console.log(`Deployed ExecutableSample for ${chain.name} at ${chain.contract.address}.`);
 }
 

--- a/examples/evm/call-contract/index.js
+++ b/examples/evm/call-contract/index.js
@@ -15,9 +15,7 @@ async function deploy(chain, wallet) {
 
 async function execute(chains, wallet, options) {
     const args = options.args || [];
-    const calculateBridgeFee = options.calculateBridgeFee;
-    const source = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
-    const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
+    const { source, destination, calculateBridgeFee } = options;
     const message = args[2] || `Hello ${destination.name} from ${source.name}, it is ${new Date().toLocaleTimeString()}.`;
 
     async function logValue() {

--- a/examples/evm/call-contract/index.js
+++ b/examples/evm/call-contract/index.js
@@ -1,10 +1,6 @@
 'use strict';
 
 const {
-    getDefaultProvider,
-    constants: { AddressZero },
-} = require('ethers');
-const {
     utils: { deployContract },
 } = require('@axelar-network/axelar-local-dev');
 
@@ -20,7 +16,6 @@ async function deploy(chain, wallet) {
 async function execute(chains, wallet, options) {
     const args = options.args || [];
     const calculateBridgeFee = options.calculateBridgeFee;
-
     const source = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
     const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
     const message = args[2] || `Hello ${destination.name} from ${source.name}, it is ${new Date().toLocaleTimeString()}.`;

--- a/examples/evm/cross-chain-token/README.md
+++ b/examples/evm/cross-chain-token/README.md
@@ -30,7 +30,7 @@ This example deploys the contract on a local network, mints 1 token on the Ether
 
 ```bash
 npm run deploy evm/cross-chain-token local
-npm run execute evm/cross-chain-token local "Ethereum" "Fantom" 1
+npm run execute evm/cross-chain-token local "Avalanche" "Fantom" 1
 ```
 
 The output will be:

--- a/examples/evm/cross-chain-token/index.js
+++ b/examples/evm/cross-chain-token/index.js
@@ -33,7 +33,7 @@ async function deploy(chain, wallet) {
 
 async function execute(chains, wallet, options) {
     const args = options.args || [];
-    const getGasPrice = options.getGasPrice;
+    const calculateBridgeFee = options.calculateBridgeFee;
 
     const source = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
     const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
@@ -50,16 +50,14 @@ async function execute(chains, wallet, options) {
     console.log('--- Initially ---');
     await print();
 
-    // Set the gasLimit to 3e5 (a safe overestimate) and get the gas price (this is constant and always 1).
-    const gasLimit = 3e5;
-    const gasPrice = await getGasPrice(source, destination, AddressZero);
+    const fee = await calculateBridgeFee(source, destination);
     await (await source.contract.giveMe(amount)).wait();
     console.log('--- After getting some token on the source chain ---');
     await print();
 
     await (
         await source.contract.transferRemote(destination.name, wallet.address, amount, {
-            value: BigInt(Math.floor(gasLimit * gasPrice)),
+            value: fee,
         })
     ).wait();
 

--- a/examples/evm/cross-chain-token/index.js
+++ b/examples/evm/cross-chain-token/index.js
@@ -33,10 +33,7 @@ async function deploy(chain, wallet) {
 
 async function execute(chains, wallet, options) {
     const args = options.args || [];
-    const calculateBridgeFee = options.calculateBridgeFee;
-
-    const source = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
-    const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
+    const { source, destination, calculateBridgeFee } = options;
     const amount = parseInt(args[2]) || 1e5;
 
     async function print() {

--- a/examples/evm/deposit-address/index.js
+++ b/examples/evm/deposit-address/index.js
@@ -9,9 +9,7 @@ const IERC20 = rootRequire('./artifacts/@axelar-network/axelar-gmp-sdk-solidity/
 
 async function execute(chains, wallet, options = {}) {
     const args = options.args || [];
-    const getDepositAddress = options.getDepositAddress;
-    const source = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
-    const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
+    const { source, destination, getDepositAddress } = options;
     const amount = args[2] || 10e6;
     const destinationAddress = args[3] || wallet.address;
     const symbol = 'aUSDC';

--- a/examples/evm/forecall/README.md
+++ b/examples/evm/forecall/README.md
@@ -1,4 +1,4 @@
-# Forecall
+# Forecall (Deprecated)
 
 > Note: This example uses forecallable which is deprecated.
 > Todo: Migrate to GMP Express.

--- a/examples/evm/forecall/index.js
+++ b/examples/evm/forecall/index.js
@@ -36,8 +36,7 @@ async function deploy(chain, wallet) {
 
 async function execute(chains, wallet, options) {
     const args = options.args || [];
-    const source = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
-    const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
+    const { source, destination } = options;
     const amount = Math.floor(parseFloat(args[2])) * 1e6 || 10e6;
     const accounts = args.slice(3);
     if (accounts.length === 0) accounts.push('0xe7490F73133dfE46D9734B1963EBe00Cb656Ed47');

--- a/examples/evm/nft-auctionhouse/bidRemote.js
+++ b/examples/evm/nft-auctionhouse/bidRemote.js
@@ -27,8 +27,7 @@ async function bidRemote(sourceChain, destinationChain, privateKey, tokenId, amo
         }
     }
 
-    const gasLimit = 3e5;
-    const gasPrice = (await options?.getGasPrice(sourceChain, destinationChain, AddressZero)) || 1;
+    const bridgeFee = await options.calculateBridgeFee(sourceChain, destinationChain);
 
     const fee = (await options?.getFee(sourceChain, destinationChain, 'aUSDC')) || 1e6;
     await (await usdc.approve(auctionhouse.address, amount + fee)).wait();
@@ -40,7 +39,7 @@ async function bidRemote(sourceChain, destinationChain, privateKey, tokenId, amo
             tokenId,
             wallet.address,
             BigInt(amount + fee),
-            { value: gasLimit * gasPrice },
+            { value: bridgeFee },
         )
     ).wait();
 

--- a/examples/evm/nft-linker/README.md
+++ b/examples/evm/nft-linker/README.md
@@ -36,7 +36,7 @@ To deploy the NFT Linker locally and send the NFT originally minted on Avalanche
 
 ```bash
 npm run deploy evm/nft-linker local
-npm run execute evm/nft-linker local "Avalanche" "Polygon"
+npm run execute evm/nft-linker local "Avalanche" "Fantom"
 ```
 
 Output:

--- a/examples/evm/nft-linker/index.js
+++ b/examples/evm/nft-linker/index.js
@@ -20,7 +20,7 @@ const tokenId = 0;
 async function deploy(chain, wallet) {
     console.log(`Deploying ERC721Demo for ${chain.name}.`);
     chain.erc721 = await deployContract(wallet, ERC721, ['Test', 'TEST']);
-    console.log(`Deployed ERC721Demo for ${chain.name} at ${chain.erc721}.`);
+    console.log(`Deployed ERC721Demo for ${chain.name} at ${chain.erc721.address}.`);
     console.log(`Deploying NftLinker for ${chain.name}.`);
     const provider = getDefaultProvider(chain.rpc);
     chain.wallet = wallet.connect(provider);

--- a/examples/evm/nft-linker/index.js
+++ b/examples/evm/nft-linker/index.js
@@ -42,7 +42,7 @@ async function deploy(chain, wallet) {
 
 async function execute(chains, wallet, options) {
     const args = options.args || [];
-    const getGasPrice = options.getGasPrice;
+    const calculateBridgeFee = options.calculateBridgeFee;
 
     const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
     const originChain = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
@@ -87,8 +87,7 @@ async function execute(chains, wallet, options) {
     console.log('--- Initially ---');
     await print();
 
-    const gasLimit = 1e6;
-    const gasPrice = await getGasPrice(source, destination, AddressZero);
+    const fee = await calculateBridgeFee(source, destination);
 
     if (originChain === source) {
         await (await source.erc721.approve(source.contract.address, owner.tokenId)).wait();
@@ -100,7 +99,7 @@ async function execute(chains, wallet, options) {
             owner.tokenId,
             destination.name,
             wallet.address,
-            { value: gasLimit * gasPrice },
+            { value: fee },
         )
     ).wait();
 

--- a/examples/evm/nft-linker/index.js
+++ b/examples/evm/nft-linker/index.js
@@ -41,11 +41,7 @@ async function deploy(chain, wallet) {
 }
 
 async function execute(chains, wallet, options) {
-    const args = options.args || [];
-    const calculateBridgeFee = options.calculateBridgeFee;
-
-    const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
-    const originChain = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
+    const { source: originChain, destination, calculateBridgeFee } = options;
 
     const ownerOf = async (chain = originChain) => {
         const operator = chain.erc721;

--- a/examples/evm/send-ack/README.md
+++ b/examples/evm/send-ack/README.md
@@ -24,7 +24,7 @@ npm run execute evm/send-ack [local|testnet] ${srcChain} ${destChain} ${message}
 
 ```bash
 npm run deploy evm/send-ack local
-npm run execute evm/send-ack local "Fantom" "Moonbeam" 'Received'
+npm run execute evm/send-ack local "Avalanche" "Fantom" 'Received'
 ```
 
 **Output:**

--- a/examples/evm/send-ack/index.js
+++ b/examples/evm/send-ack/index.js
@@ -31,11 +31,7 @@ async function deploy(chain, wallet) {
 }
 
 async function execute(chains, wallet, options) {
-    const args = options.args || [];
-    const calculateBridgeFee = options.calculateBridgeFee;
-
-    const source = chains.find((chain) => chain.name === (args[0] || 'Avalanche'));
-    const destination = chains.find((chain) => chain.name === (args[1] || 'Fantom'));
+    const { source, destination, calculateBridgeFee, args } = options;
     const message = args[2] || `Hello, the time is ${time}.`;
     const payload = defaultAbiCoder.encode(['string'], [message]);
 

--- a/scripts/libs/deploy.js
+++ b/scripts/libs/deploy.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('dotenv').config();
-require('./rootRequire');
 const {
     utils: { setJSON },
 } = require('@axelar-network/axelar-local-dev');

--- a/scripts/libs/deploy.js
+++ b/scripts/libs/deploy.js
@@ -2,7 +2,6 @@
 
 require('dotenv').config();
 require('./rootRequire');
-
 const {
     utils: { setJSON },
 } = require('@axelar-network/axelar-local-dev');

--- a/scripts/libs/execute.js
+++ b/scripts/libs/execute.js
@@ -47,6 +47,7 @@ async function execute(env, chains, args, wallet, example) {
 function deserializeContract(chain, wallet) {
     // Loop through every keys in the chain object.
     for (const key of Object.keys(chain)) {
+
         // If the object has an abi, it is a contract.
         if (chain[key].abi) {
             // Get the contract object.
@@ -56,6 +57,8 @@ function deserializeContract(chain, wallet) {
             chain[key] = new Contract(contract.address, contract.abi, wallet);
         }
     }
+
+    return chain;
 }
 
 module.exports = {

--- a/scripts/libs/execute.js
+++ b/scripts/libs/execute.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('dotenv').config();
-require('./rootRequire');
 const { Contract, getDefaultProvider } = require('ethers');
 const { calculateBridgeFee, getDepositAddress, sanitizeEventArgs } = require('./utils.js');
 const AxelarGatewayContract = rootRequire(

--- a/scripts/libs/execute.js
+++ b/scripts/libs/execute.js
@@ -37,7 +37,7 @@ async function execute(env, chains, args, wallet, example) {
     }
 
     await example.execute(chains, wallet, {
-        calculateBridgeFee: (source, destination, tokenAddress) => calculateBridgeFee(env, source, destination, tokenAddress),
+        calculateBridgeFee,
         getDepositAddress: (source, destination, destinationAddress, symbol) =>
             getDepositAddress(env, source, destination, destinationAddress, symbol),
         args,
@@ -47,7 +47,6 @@ async function execute(env, chains, args, wallet, example) {
 function deserializeContract(chain, wallet) {
     // Loop through every keys in the chain object.
     for (const key of Object.keys(chain)) {
-
         // If the object has an abi, it is a contract.
         if (chain[key].abi) {
             // Get the contract object.

--- a/scripts/libs/execute.js
+++ b/scripts/libs/execute.js
@@ -3,7 +3,7 @@
 require('dotenv').config();
 require('./rootRequire');
 const { Contract, getDefaultProvider } = require('ethers');
-const { getGasPrice, getDepositAddress } = require('./utils.js');
+const { calculateBridgeFee, getDepositAddress } = require('./utils.js');
 
 const AxelarGatewayContract = rootRequire(
     'artifacts/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGateway.sol/IAxelarGateway.json',
@@ -37,7 +37,7 @@ async function execute(env, chains, args, wallet, example) {
     }
 
     await example.execute(chains, wallet, {
-        getGasPrice: (source, destination, tokenAddress) => getGasPrice(env, source, destination, tokenAddress),
+        calculateBridgeFee: (source, destination, tokenAddress) => calculateBridgeFee(env, source, destination, tokenAddress),
         getDepositAddress: (source, destination, destinationAddress, symbol) =>
             getDepositAddress(env, source, destination, destinationAddress, symbol),
         args,

--- a/scripts/libs/execute.js
+++ b/scripts/libs/execute.js
@@ -4,7 +4,6 @@ require('dotenv').config();
 require('./rootRequire');
 const { Contract, getDefaultProvider } = require('ethers');
 const { calculateBridgeFee, getDepositAddress, sanitizeEventArgs } = require('./utils.js');
-
 const AxelarGatewayContract = rootRequire(
     'artifacts/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGateway.sol/IAxelarGateway.json',
 );

--- a/scripts/libs/index.js
+++ b/scripts/libs/index.js
@@ -1,3 +1,6 @@
+require('dotenv').config();
+require('./rootRequire');
+
 module.exports = {
     ...require('./start'),
     ...require('./deploy'),

--- a/scripts/libs/start.js
+++ b/scripts/libs/start.js
@@ -1,4 +1,3 @@
-require('dotenv').config();
 const { ethers } = require('ethers');
 const { createAndExport, createAptosNetwork } = require('@axelar-network/axelar-local-dev');
 const path = require('path');

--- a/scripts/libs/utils.js
+++ b/scripts/libs/utils.js
@@ -34,7 +34,9 @@ function getChains(env, testnetChains = ['Avalanche', 'Fantom']) {
         return rootRequire('chain-config/local.json');
     }
 
-    return require(`@axelar-network/axelar-cgp-solidity/info/testnet.json`)
+    const testnet = rootRequire('chain-config/testnet.json') || require(`@axelar-network/axelar-cgp-solidity/info/testnet.json`);
+
+    return testnet
         .filter((chain) => {
             return testnetChains.includes(chain.name);
         })

--- a/scripts/libs/utils.js
+++ b/scripts/libs/utils.js
@@ -114,24 +114,41 @@ async function calculateBridgeFee(source, destination, options = {}) {
     return api.estimateGasFee(source.name, destination.name, symbol || source.tokenSymbol, gasLimit, gasMultiplier || 1.5);
 }
 
-// Check if the wallet is set. If not, throw an error.
+/**
+ * Check if the wallet is set. If not, throw an error.
+ */
 function checkWallet() {
     if (process.env.EVM_PRIVATE_KEY == null && process.env.EVM_MNEMONIC == null) {
         throw new Error('Need to set EVM_PRIVATE_KEY or EVM_MNEMONIC environment variable.');
     }
 }
 
+/**
+ * Check if the environment is set. If not, throw an error.
+ * @param {*} env - The environment to check. Available options are 'local' and 'testnet'.
+ */
 function checkEnv(env) {
     if (env == null || (env !== 'testnet' && env !== 'local')) {
         throw new Error('Need to specify testnet or local as an argument to this script.');
     }
 }
 
+/**
+ * Get the path to an example.
+ * @param {*} exampleName - The name of the example to get the path for.
+ * @returns {string} - The path to the example.
+ */
 function getExamplePath(exampleName) {
     const destDir = path.resolve(__dirname, '..', `examples/${exampleName}/index.js`);
     return path.relative(__dirname, destDir);
 }
 
+/**
+ * Sanitize the event arguments.
+ * This is needed because ethers.js returns the event arguments as an object with the keys being the argument names and the values being the argument values.
+ * @param {*} event - The event to sanitize.
+ * @returns {Object} - The sanitized event arguments.
+ */
 function sanitizeEventArgs(event) {
     return Object.keys(event.args).reduce((acc, key) => {
         if (isNaN(parseInt(key))) {
@@ -150,5 +167,5 @@ module.exports = {
     checkEnv,
     calculateBridgeFee,
     getExamplePath,
-    sanitizeEventArgs
+    sanitizeEventArgs,
 };

--- a/scripts/libs/utils.js
+++ b/scripts/libs/utils.js
@@ -132,6 +132,16 @@ function getExamplePath(exampleName) {
     return path.relative(__dirname, destDir);
 }
 
+function sanitizeEventArgs(event) {
+    return Object.keys(event.args).reduce((acc, key) => {
+        if (isNaN(parseInt(key))) {
+            acc[key] = event.args[key];
+        }
+
+        return acc;
+    }, {});
+}
+
 module.exports = {
     getWallet,
     getDepositAddress,
@@ -140,4 +150,5 @@ module.exports = {
     checkEnv,
     calculateBridgeFee,
     getExamplePath,
+    sanitizeEventArgs
 };

--- a/scripts/libs/utils.js
+++ b/scripts/libs/utils.js
@@ -20,6 +20,18 @@ function getWallet() {
 }
 
 /**
+ * Get testnet chains config from local if it exists, otherwise from axelar-cgp-solidity.
+ */
+function getTestnetConfig() {
+    // check if the testnet config file exists
+    try {
+        return rootRequire('chain-config/testnet.json');
+    } catch (e) {
+        return require(`@axelar-network/axelar-cgp-solidity/info/testnet.json`);
+    }
+}
+
+/**
  * Get the chain objects from the chain-config file.
  * @param {*} env - The environment to get the chain objects for. Available options are 'local' and 'testnet'.
  * @param {*} testnetChains - The list of chains to get the chain objects for if the environment is 'testnet'.
@@ -34,9 +46,7 @@ function getChains(env, testnetChains = ['Avalanche', 'Fantom']) {
         return rootRequire('chain-config/local.json');
     }
 
-    const testnet = rootRequire('chain-config/testnet.json') || require(`@axelar-network/axelar-cgp-solidity/info/testnet.json`);
-
-    return testnet
+    return getTestnetConfig()
         .filter((chain) => {
             return testnetChains.includes(chain.name);
         })

--- a/scripts/libs/utils.js
+++ b/scripts/libs/utils.js
@@ -82,7 +82,7 @@ async function getBalances(chains, address) {
 function getDepositAddress(env, source, destination, destinationAddress, symbol) {
     if (env === 'testnet') {
         const listing = {
-            aUSDC: 'uusdc',
+            aUSDC: env === 'local' ? 'uusdc' : 'uausdc',
         };
         const sdk = new AxelarAssetTransfer({
             environment: 'testnet',

--- a/scripts/libs/utils.js
+++ b/scripts/libs/utils.js
@@ -22,16 +22,26 @@ function getWallet() {
 /**
  * Get the chain objects from the chain-config file.
  * @param {*} env - The environment to get the chain objects for. Available options are 'local' and 'testnet'.
+ * @param {*} testnetChains - The list of chains to get the chain objects for if the environment is 'testnet'.
+ * Checks the following file for available chain names https://github.com/axelarnetwork/axelar-cgp-solidity/blob/main/info/testnet.json
+ * The default list of chains is ['Avalanche', 'Fantom']
  * @returns {Chain[]} - The chain objects.
  */
-function getChains(env) {
+function getChains(env, testnetChains = ['Avalanche', 'Fantom']) {
     checkEnv(env);
 
     if (env === 'local') {
         return rootRequire('chain-config/local.json');
     }
 
-    return require("@axelar-network/axelar-cgp-solidity/info/testnet.json");
+    return require(`@axelar-network/axelar-cgp-solidity/info/testnet.json`)
+        .filter((chain) => {
+            return testnetChains.includes(chain.name);
+        })
+        .map((chain) => ({
+            ...chain,
+            gasService: chain.AxelarGasService.address,
+        }));
 }
 
 /**

--- a/scripts/libs/utils.js
+++ b/scripts/libs/utils.js
@@ -1,4 +1,3 @@
-require('./rootRequire');
 const { Wallet, ethers } = require('ethers');
 const path = require('path');
 const axelarLocal = require('@axelar-network/axelar-local-dev');

--- a/scripts/libs/utils.js
+++ b/scripts/libs/utils.js
@@ -1,10 +1,5 @@
 require('./rootRequire');
-const {
-    constants: { AddressZero },
-    Wallet,
-    ethers,
-} = require('ethers');
-const axios = require('axios');
+const { Wallet, ethers } = require('ethers');
 const path = require('path');
 const axelarLocal = require('@axelar-network/axelar-local-dev');
 const { AxelarAssetTransfer, AxelarQueryAPI } = require('@axelar-network/axelarjs-sdk');

--- a/scripts/libs/utils.js
+++ b/scripts/libs/utils.js
@@ -108,10 +108,10 @@ function getDepositAddress(env, source, destination, destinationAddress, symbol)
  * @param {*} options - The options to pass to the estimateGasFee function. Available options are gasLimit and gasMultiplier.
  * @returns {number} - The gas amount.
  */
-async function calculateBridgeFee(source, destination, symbol = source.tokenSymbol, options = {}) {
+async function calculateBridgeFee(source, destination, options = {}) {
     const api = new AxelarQueryAPI({ environment: 'testnet' });
-    const { gasLimit, gasMultiplier } = options;
-    return api.estimateGasFee(source.name, destination.name, symbol, gasLimit, gasMultiplier || 1.5);
+    const { gasLimit, gasMultiplier, symbol } = options;
+    return api.estimateGasFee(source.name, destination.name, symbol || source.tokenSymbol, gasLimit, gasMultiplier || 1.5);
 }
 
 // Check if the wallet is set. If not, throw an error.


### PR DESCRIPTION
# Description

Closes #94

- Fix testnet examples

All examples are working except `forecall`, `cross-chain-lending`. These examples use `forecallable` which is deprecated. will upgrade to gmp express later.