### PR TITLE
chore: fix web nft linker example doesn't work

### DIFF
--- a/examples-web/contracts/nft-linker/Proxy.sol
+++ b/examples-web/contracts/nft-linker/Proxy.sol
@@ -2,15 +2,20 @@
 
 pragma solidity 0.8.9;
 
-import {InitProxy} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/upgradable/InitProxy.sol";
+import {Proxy} from "@axelar-network/axelar-gmp-sdk-solidity/contracts/upgradable/Proxy.sol";
 
-contract ExampleProxy is InitProxy {
-    function contractId()
-        internal
-        pure
-        override
-        returns (bytes32)
-    {
-        return keccak256("example");
+contract ExampleProxy is Proxy {
+    bytes32 internal constant CONTRACT_ID = keccak256('token-linker');
+
+    constructor(
+        address implementationAddress,
+        address owner,
+        bytes memory setupParams
+    ) Proxy(implementationAddress, owner, setupParams) {}
+
+    function contractId() internal pure override returns (bytes32) {
+        return CONTRACT_ID;
     }
+
+    receive() external payable override {}
 }

--- a/examples-web/hardhat.config.js
+++ b/examples-web/hardhat.config.js
@@ -1,5 +1,8 @@
 require("hardhat-gas-reporter");
 require("solidity-coverage");
+require('@typechain/hardhat')
+// require('@nomiclabs/hardhat-ethers')
+// require('@nomiclabs/hardhat-waffle')
 
 /**
  * @type import('hardhat/config').HardhatUserConfig
@@ -30,5 +33,9 @@ module.exports = {
   },
   paths: {
     sources: "./contracts",
+  },
+  typechain: {
+    outDir: 'src/types',
+    target: 'ethers-v5',
   },
 };

--- a/examples-web/hardhat.config.js
+++ b/examples-web/hardhat.config.js
@@ -1,8 +1,6 @@
 require("hardhat-gas-reporter");
 require("solidity-coverage");
 require('@typechain/hardhat')
-// require('@nomiclabs/hardhat-ethers')
-// require('@nomiclabs/hardhat-waffle')
 
 /**
  * @type import('hardhat/config').HardhatUserConfig

--- a/examples-web/package-lock.json
+++ b/examples-web/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@typechain/ethers-v5": "^10.2.0",
+        "@typechain/hardhat": "^6.1.5",
         "@types/node": "18.0.1",
         "@types/react": "18.0.14",
         "@types/react-dom": "18.0.6",
@@ -2172,6 +2173,38 @@
         "typescript": ">=4.3.0"
       }
     },
+    "node_modules/@typechain/hardhat": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-6.1.5.tgz",
+      "integrity": "sha512-lg7LW4qDZpxFMknp3Xool61Fg6Lays8F8TXdFGBG+MxyYcYU5795P1U2XdStuzGq9S2Dzdgh+1jGww9wvZ6r4Q==",
+      "dev": true,
+      "dependencies": {
+        "fs-extra": "^9.1.0"
+      },
+      "peerDependencies": {
+        "@ethersproject/abi": "^5.4.7",
+        "@ethersproject/providers": "^5.4.7",
+        "@typechain/ethers-v5": "^10.2.0",
+        "ethers": "^5.4.7",
+        "hardhat": "^2.9.9",
+        "typechain": "^8.1.1"
+      }
+    },
+    "node_modules/@typechain/hardhat/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@types/async-eventemitter": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@types/async-eventemitter/-/async-eventemitter-0.2.1.tgz",
@@ -2962,6 +2995,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.7",
@@ -15974,6 +16016,29 @@
         "ts-essentials": "^7.0.1"
       }
     },
+    "@typechain/hardhat": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-6.1.5.tgz",
+      "integrity": "sha512-lg7LW4qDZpxFMknp3Xool61Fg6Lays8F8TXdFGBG+MxyYcYU5795P1U2XdStuzGq9S2Dzdgh+1jGww9wvZ6r4Q==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^9.1.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
+      }
+    },
     "@types/async-eventemitter": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@types/async-eventemitter/-/async-eventemitter-0.2.1.tgz",
@@ -16595,6 +16660,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
     },
     "autoprefixer": {
       "version": "10.4.7",

--- a/examples-web/package.json
+++ b/examples-web/package.json
@@ -6,12 +6,11 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "deploy": "run-s contracts:build contracts:generate contracts:deploy",
+    "deploy": "run-s contracts:build contracts:deploy",
     "lint": "next lint",
     "setup": "ts-node scripts/setup.ts",
     "contracts:build": "hardhat compile",
-    "contracts:deploy": "ts-node scripts/deploy-contracts.ts",
-    "contracts:generate": "typechain --target ethers-v5 --out-dir src/types/contracts artifacts/*[!build-info]/**/*[!dbg].json"
+    "contracts:deploy": "ts-node scripts/deploy-contracts.ts"
   },
   "dependencies": {
     "@axelar-network/axelar-gmp-sdk-solidity": "^3.2.1",
@@ -28,6 +27,7 @@
   },
   "devDependencies": {
     "@typechain/ethers-v5": "^10.2.0",
+    "@typechain/hardhat": "^6.1.5",
     "@types/node": "18.0.1",
     "@types/react": "18.0.14",
     "@types/react-dom": "18.0.6",

--- a/examples-web/package.json
+++ b/examples-web/package.json
@@ -6,11 +6,12 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "deploy": "run-s contracts:build contracts:deploy",
+    "deploy": "run-s contracts:clean contracts:build contracts:deploy",
     "lint": "next lint",
     "setup": "ts-node scripts/setup.ts",
-    "contracts:build": "hardhat compile",
-    "contracts:deploy": "ts-node scripts/deploy-contracts.ts"
+    "contracts:build": "hardhat clean && hardhat compile",
+    "contracts:deploy": "ts-node scripts/deploy-contracts.ts",
+    "contracts:clean": "rm -rf artifacts src/types"
   },
   "dependencies": {
     "@axelar-network/axelar-gmp-sdk-solidity": "^3.2.1",

--- a/examples-web/scripts/call-contract-with-token/deploy.ts
+++ b/examples-web/scripts/call-contract-with-token/deploy.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { getDefaultProvider, Wallet } from "ethers";
-import {MessageSender__factory as CallContractWithTokenSenderFactory, MessageReceiver__factory as CallContractWithTokenReceiverFactory} from '../../src/types/contracts/factories/contracts/call-contract-with-token/contracts'
+import {MessageSender__factory as CallContractWithTokenSenderFactory, MessageReceiver__factory as CallContractWithTokenReceiverFactory} from '../../src/types/factories/contracts/call-contract-with-token/contracts'
 
 export async function deploy(wallet: Wallet, chainA: any, chainB: any) {
   // deploy on ethereum

--- a/examples-web/scripts/call-contract/deploy.ts
+++ b/examples-web/scripts/call-contract/deploy.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import { getDefaultProvider, Wallet } from "ethers";
-import {MessageSender__factory as CallContractSenderFactory, MessageReceiver__factory as CallContractReceiverFactory} from '../../src/types/contracts/factories/contracts/call-contract'
+import {MessageSender__factory as CallContractSenderFactory, MessageReceiver__factory as CallContractReceiverFactory} from '../../src/types/factories/contracts/call-contract'
 
 export async function deploy(wallet: Wallet, chainA: any, chainB: any) {
   // deploy on ethereum

--- a/examples-web/scripts/nft-linker/deploy.ts
+++ b/examples-web/scripts/nft-linker/deploy.ts
@@ -1,8 +1,8 @@
 import { getDefaultProvider, utils, Wallet } from 'ethers';
-import { ExampleProxy__factory as ExampleProxy } from '../../src/types/contracts/factories/contracts/nft-linker/Proxy.sol'
-import { ERC721Demo__factory as ERC721Demo } from '../../src/types/contracts/factories/contracts/nft-linker/ERC721demo.sol'
-import { NftLinker__factory as NFTLinker} from '../../src/types/contracts/factories/contracts/nft-linker/NFTLinker.sol/'
-const { deployUpgradable } = require('@axelar-network/axelar-gmp-sdk-solidity');
+import { ExampleProxy__factory as ExampleProxy } from '../../src/types/factories/contracts/nft-linker/Proxy.sol'
+import { ERC721Demo__factory as ERC721Demo } from '../../src/types/factories/contracts/nft-linker/ERC721demo.sol'
+import { NftLinker__factory as NFTLinker} from '../../src/types/factories/contracts/nft-linker/NFTLinker.sol/'
+const { deployUpgradable, deployCreate3Upgradable } = require('@axelar-network/axelar-gmp-sdk-solidity');
 
 const nftTokenId = 0;
 
@@ -28,8 +28,8 @@ export async function deploy(wallet: Wallet, chainA: any, chainB: any) {
   await erc721B.mint(nftTokenId)
     .then((tx: any) => tx.wait(1));
 
-  const nftLinkerA = await deployUpgradable(
-      chainA.constAddressDeployer,
+  const nftLinkerA = await deployCreate3Upgradable(
+      chainA.create3Deployer,
       walletA,
       NFTLinker,
       ExampleProxy,
@@ -39,8 +39,8 @@ export async function deploy(wallet: Wallet, chainA: any, chainB: any) {
   );
   chainA.nftLinker = nftLinkerA.address;
 
-  const nftLinkerB = await deployUpgradable(
-    chainB.constAddressDeployer,
+  const nftLinkerB = await deployCreate3Upgradable(
+    chainB.create3Deployer,
     walletB,
     NFTLinker,
     ExampleProxy,

--- a/examples-web/scripts/nft-linker/deploy.ts
+++ b/examples-web/scripts/nft-linker/deploy.ts
@@ -28,6 +28,7 @@ export async function deploy(wallet: Wallet, chainA: any, chainB: any) {
   await erc721B.mint(nftTokenId)
     .then((tx: any) => tx.wait(1));
 
+  const salt = new Date().getTime().toString();
   const nftLinkerA = await deployCreate3Upgradable(
       chainA.create3Deployer,
       walletA,
@@ -36,6 +37,7 @@ export async function deploy(wallet: Wallet, chainA: any, chainB: any) {
       [chainA.gateway, chainA.gasService],
       [],
       utils.defaultAbiCoder.encode(['string'], [chainA.name]),
+      salt
   );
   chainA.nftLinker = nftLinkerA.address;
 
@@ -47,6 +49,7 @@ export async function deploy(wallet: Wallet, chainA: any, chainB: any) {
     [chainB.gateway, chainB.gasService],
     [],
     utils.defaultAbiCoder.encode(['string'], [chainB.name]),
+    salt
   );
   chainB.nftLinker = nftLinkerB.address;
 

--- a/examples-web/src/helpers/call-contract-with-token/index.ts
+++ b/examples-web/src/helpers/call-contract-with-token/index.ts
@@ -6,8 +6,8 @@ import {
   GasToken,
 } from "@axelar-network/axelarjs-sdk";
 
-import {MessageReceiver__factory as MessageReceiverFactory, MessageSender__factory as MessageSenderFactory} from 'types/contracts/factories/contracts/call-contract-with-token/contracts'
-import {IAxelarGateway__factory as AxelarGatewayFactory, IERC20__factory as IERC20Factory } from 'types/contracts/factories/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces'
+import {MessageReceiver__factory as MessageReceiverFactory, MessageSender__factory as MessageSenderFactory} from 'types/factories/contracts/call-contract-with-token/contracts'
+import {IAxelarGateway__factory as AxelarGatewayFactory, IERC20__factory as IERC20Factory } from 'types/factories/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces'
 import { isTestnet, srcChain, srcConnectedWallet, destChain, destConnectedWallet } from "config/constants";
 
 const srcGatewayContract = AxelarGatewayFactory.connect(srcChain.gateway, srcConnectedWallet)

--- a/examples-web/src/helpers/call-contract/index.ts
+++ b/examples-web/src/helpers/call-contract/index.ts
@@ -7,7 +7,7 @@ import {
 import {
   MessageSender__factory as MessageSenderFactory,
   MessageReceiver__factory as MessageReceiverFactory,
-} from "types/contracts/factories/contracts/call-contract";
+} from "types/factories/contracts/call-contract";
 
 const sourceContract = MessageSenderFactory.connect(
   srcChain?.callContract,

--- a/examples-web/src/helpers/nft-linker/index.ts
+++ b/examples-web/src/helpers/nft-linker/index.ts
@@ -101,8 +101,6 @@ export async function sendNftBack(
 
     await sleep(2000);
   }
-
-  await print();
 }
 
 export const ownerOf = async (chain = srcChain) => {

--- a/examples-web/src/helpers/nft-linker/index.ts
+++ b/examples-web/src/helpers/nft-linker/index.ts
@@ -4,8 +4,8 @@ import {
   EvmChain,
   GasToken,
 } from "@axelar-network/axelarjs-sdk";
-import { ERC721Demo__factory as ERC721 } from "types/contracts/factories/contracts/nft-linker/ERC721demo.sol";
-import { NftLinker__factory as NftLinker } from "types/contracts/factories/contracts/nft-linker/NFTLinker.sol";
+import { ERC721Demo__factory as ERC721 } from "types/factories/contracts/nft-linker/ERC721demo.sol";
+import { NftLinker__factory as NftLinker } from "types/factories/contracts/nft-linker/NFTLinker.sol";
 import {
   isTestnet,
   wallet,
@@ -15,6 +15,7 @@ import {
   destConnectedWallet,
 } from "config/constants";
 import { defaultAbiCoder, keccak256 } from "ethers/lib/utils";
+import { nftLinker } from "types/contracts/contracts";
 
 const tokenId = 0;
 
@@ -36,6 +37,7 @@ export async function sendNftToDest(
   await srcErc721
     .approve(srcNftLinker.address, owner.tokenId || tokenId)
     .then((tx: any) => tx.wait());
+
   const tx = await (
     await srcNftLinker.sendNFT(
       srcErc721.address,
@@ -89,6 +91,7 @@ export async function sendNftBack(
   onSrcConfirmed(tx.transactionHash);
 
   while (true) {
+    // console.log(await srcNftLinker.hello());
     const owner = await ownerOf();
 
     if (owner.chain === srcChain.name) {
@@ -132,14 +135,16 @@ export const ownerOf = async (chain = srcChain) => {
     const nftLinker = checkingChain.name === srcChain.name ? srcNftLinker : destNftLinker;
 
     try {
-      const address = await nftLinker.ownerOf(newTokenId);
+      const address = await nftLinker.ownerOf(newTokenId.toString());
       return {
         chain: checkingChain.name,
         address,
-        tokenId: newTokenId,
+        tokenId: newTokenId.toString(),
         tokenURI: metadata,
       };
-    } catch (e) {}
+    } catch (e) {
+
+    }
   }
 
   return { chain: "" };

--- a/examples-web/src/helpers/send-tokens/depositAddressSendToken.ts
+++ b/examples-web/src/helpers/send-tokens/depositAddressSendToken.ts
@@ -3,7 +3,7 @@ import { AxelarAssetTransfer, Environment } from "@axelar-network/axelarjs-sdk";
 import {
   IERC20__factory as IERC20,
   IAxelarGateway__factory as IAxelarGateway,
-} from "types/contracts/factories/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces";
+} from "types/factories/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces";
 import {
   srcChain,
   srcConnectedWallet,

--- a/examples-web/src/helpers/send-tokens/gatewaySendToken.ts
+++ b/examples-web/src/helpers/send-tokens/gatewaySendToken.ts
@@ -2,7 +2,7 @@ import { ethers } from "ethers";
 import {
   IERC20__factory as IERC20,
   IAxelarGateway__factory as IAxelarGateway,
-} from "types/contracts/factories/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces";
+} from "types/factories/@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces";
 import {
   srcChain,
   srcConnectedWallet,


### PR DESCRIPTION
# Description

- Closes #111 
- Closes #110 

This PR addresses the NFT linker example issue by ensuring the same salt is used for deployment, which allows for consistent contract addresses across different chains. This is necessary due to the contract's source address check requiring a match with its own address.

# Other Changes
- Updated the deployment method to `deployCreate3Upgradable` to showcase this new deployment approach.
- Updated to use `@typechain/hardhat` to generate type automatically after the compilation step, eliminating the need for an additional command to be run explicitly.

