### PR TITLE
docs: add a step to run node locally before printing balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ cp .env.example .env
 
 Then update to your own private key.
 
+## Running the local chains
+
+```bash
+npm run start
+```
+
+Leave this node running on a separate terminal before deploying and testing the dApps.
+
 ## Print wallet balances
 
 This script will print your wallet balances for each chain.
@@ -55,14 +63,6 @@ npm run check-balance [local|testnet]
 ```
 
 If not specified, this will print balances of the wallet for testnet.
-
-## Running the local chains
-
-```bash
-npm run start
-```
-
-Leave this node running on a separate terminal before deploying and testing the dApps.
 
 ## Examples
 


### PR DESCRIPTION
After cloning the project, the readme instructed to print balances, but it resulted in a network error since the local node was not yet running.

Error log:

```
Error: could not detect network (event="noNetwork", code=NETWORK_ERROR, version=providers/5.7.2)
    at Logger.makeError (/axelar-examples/node_modules/@ethersproject/logger/lib/index.js:238:21)
    at Logger.throwError (/axelar/axelar-examples/node_modules/@ethersproject/logger/lib/index.js:247:20)
    at JsonRpcProvider.<anonymous> (/axelar-examples/node_modules/@ethersproject/providers/lib/json-rpc-provider.js:609:54)
    at step (/axelar-examples/node_modules/@ethersproject/providers/lib/json-rpc-provider.js:48:23)
    at Object.throw (/axelar-examples/node_modules/@ethersproject/providers/lib/json-rpc-provider.js:29:53)
    at rejected (/axelar-examples/node_modules/@ethersproject/providers/lib/json-rpc-provider.js:21:65)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  reason: 'could not detect network',
  code: 'NETWORK_ERROR',
  event: 'noNetwork'
}
```