### PR TITLE
chore: fix undefined chain name testnet

### DIFF
--- a/scripts/libs/utils.js
+++ b/scripts/libs/utils.js
@@ -35,7 +35,8 @@ function getEVMChains(env, chains = []) {
 
     return testnet.map((chain) => ({
         ...chain,
-        gasService: chain.AxelarGasService.address,
+        gateway: chain.contracts.AxelarGateway.address,
+        gasService: chain.contracts.AxelarGasService.address,
     }));
 }
 

--- a/scripts/libs/utils.js
+++ b/scripts/libs/utils.js
@@ -55,7 +55,7 @@ function getTestnetChains(chains = []) {
         const { testnetInfo } = require('@axelar-network/axelar-local-dev');
         testnet = [];
         for (const chain of chains) {
-            testnet.push(testnetInfo[chain.name.toLowerCase()]);
+            testnet.push(testnetInfo[chain.toLowerCase()]);
         }
     }
 


### PR DESCRIPTION
Fix undefined error when running `npm run deploy <example> testnet`