### PR TITLE
chore: bump axelar-local-dev to 2.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@axelar-network/axelar-chains-config": "^1.2.0",
                 "@axelar-network/axelar-gmp-sdk-solidity": "^5.9.0",
-                "@axelar-network/axelar-local-dev": "2.3.2",
+                "@axelar-network/axelar-local-dev": "^2.3.3",
                 "@axelar-network/axelar-local-dev-cosmos": "^2.3.0",
                 "@axelar-network/axelar-local-dev-multiversx": "^2.3.0",
                 "@axelar-network/axelarjs-sdk": "^0.15.0",
@@ -77,9 +77,9 @@
             }
         },
         "node_modules/@axelar-network/axelar-chains-config": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@axelar-network/axelar-chains-config/-/axelar-chains-config-1.2.0.tgz",
-            "integrity": "sha512-JGQ6Bo8J/iTq7s6iNLf3lhsZRmeVACvPAoEoGMiZA5WdNqku7x8nXGG4i36FaVOASt6UPYK10l/5D5d31fh4JQ==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@axelar-network/axelar-chains-config/-/axelar-chains-config-1.3.0.tgz",
+            "integrity": "sha512-k633v2pJF8qPM3pDSawSqm7K4AgqmGicj2fUk0O0HwWB1jS2l/oFm+x5jB58HT64xhf8x7VB4BhdJQtMdKcOPA==",
             "dependencies": {
                 "@ethersproject/keccak256": "^5.7.0",
                 "fs-extra": "^11.1.1"
@@ -94,12 +94,12 @@
             }
         },
         "node_modules/@axelar-network/axelar-local-dev": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/@axelar-network/axelar-local-dev/-/axelar-local-dev-2.3.2.tgz",
-            "integrity": "sha512-dnjSjhQ7AMQvvgKDHDU1B1miBlIbcLfaLY0uflHQYQva5UJ6wUM5CsL/ADs6W4UjLgbQGUURBs7jY9EDKn/HUQ==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/@axelar-network/axelar-local-dev/-/axelar-local-dev-2.3.3.tgz",
+            "integrity": "sha512-gRzGWJBOMxUnNJRe3zHDBha95g5EPkQo6FfXirJW0h/zmtiIKGhkBbNqtm3yQHWn05KgS4bzOp+EILj8OJOsQQ==",
             "dependencies": {
                 "@axelar-network/axelar-cgp-solidity": "^6.3.0",
-                "@axelar-network/axelar-chains-config": "^1.2.0",
+                "@axelar-network/axelar-chains-config": "^1.3.0",
                 "@axelar-network/axelar-gmp-sdk-solidity": "^5.7.0",
                 "@axelar-network/interchain-token-service": "^1.2.4",
                 "ethers": "^5.6.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@axelar-network/axelar-chains-config": "^1.2.0",
         "@axelar-network/axelar-gmp-sdk-solidity": "^5.9.0",
-        "@axelar-network/axelar-local-dev": "2.3.2",
+        "@axelar-network/axelar-local-dev": "^2.3.3",
         "@axelar-network/axelar-local-dev-cosmos": "^2.3.0",
         "@axelar-network/axelar-local-dev-multiversx": "^2.3.0",
         "@axelar-network/axelarjs-sdk": "^0.15.0",

--- a/scripts/libs/utils.js
+++ b/scripts/libs/utils.js
@@ -197,7 +197,7 @@ function getDefaultChains(env) {
         return ['Avalanche', 'Fantom', 'Moonbeam', 'Polygon', 'Ethereum'];
     }
 
-    return ['Avalanche', 'Fantom', 'Polygon'];
+    return ['Avalanche', 'Fantom', 'polygon-sepolia'];
 }
 
 /**


### PR DESCRIPTION
# Description

[AXE-4344](https://axelarnetwork.atlassian.net/browse/AXE-4344): : Fix Contract Deployment Issues on Testnet

This PR updates the `axelar-local-dev` dependency to version `2.3.3`, addressing the contract deployment issues encountered on the `testnet`.

Previously, running the command `npm run deploy evm/send-ack testnet` would result in deployment failures with the following error message:

```bash
Deploying SendAckSender for Avalanche.
Deploying SendAckSender for Fantom.
Deploying SendAckSender for Polygon.
/Users/idrisolubisi/Documents/axelar/axelar-examples/node_modules/@ethersproject/logger/lib/index.js:238
        var error = new Error(message);
                    ^

Error: could not detect network (event="noNetwork", code=NETWORK_ERROR, version=providers/5.7.2)
    at Logger.makeError
```

Updating to `axelar-local-dev` version `2.3.3` resolves these network detection issue on Polygon (which is one of the default chains in testnet). After this update, the deployment process completes successfully:

```bash
Deploying SendAckSender for Avalanche.
Deploying SendAckSender for Fantom.
Deploying SendAckSender for Polygon-Sepolia.
Deployed SendAckSender for Avalanche at 0x680F2236b346d2bF62D97680725f238114E179E2.
Deploying SendAckReceiverImplementation for Avalanche.
Deployed SendAckSender for Fantom at 0x139a753d6430bBC348075074650124E1bB2b9820.
Deploying SendAckReceiverImplementation for Fantom.
Deployed SendAckReceiverImplementation for Avalanche at 0xde6A625999A2a646Ca493041D214c1EC2C0c67cb.
Deployed SendAckReceiverImplementation for Fantom at 0x965Feb0f91Df0C55e4EBd9ace0095843eD711681.
Deployed SendAckSender for Polygon-Sepolia at 0x8b0196db342Eef7fE21BAa488a590328cAc99164.
Deploying SendAckReceiverImplementation for Polygon-Sepolia.
Deployed SendAckReceiverImplementation for Polygon-Sepolia at 0xf18D9C2B3B93Bf7dEF5d1cA3c53E5Bf4b406ed11.
```

[AXE-4344]: https://axelarnetwork.atlassian.net/browse/AXE-4344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ